### PR TITLE
Update dependencies and improve logging in the live_feeds module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     "ext-simplexml": "*",
     "ext-tidy": "*",
     "ext-libxml": "*",
-    "drupal/date_ap_style": "^1.0"
+    "drupal/date_ap_style": "^1.0 | ^2.0"
   }
 }

--- a/live_feeds.services.yml
+++ b/live_feeds.services.yml
@@ -1,6 +1,6 @@
 services:
   live_feeds.live_feed:
     class: Drupal\live_feeds\GetFeed
-    arguments: ['@http_client']
+    arguments: [ '@http_client', '@logger.factory' ]
   live_feeds.live_feeds_smart_trim:
     class: Drupal\live_feeds\LiveFeedsSmartTrim

--- a/src/LiveFeedsSmartTrim.php
+++ b/src/LiveFeedsSmartTrim.php
@@ -11,6 +11,9 @@ use Drupal\Core\Security\TrustedCallbackInterface;
  */
 class LiveFeedsSmartTrim implements TrustedCallbackInterface {
 
+  /**
+   * {@inheritDoc}
+   */
   public static function trustedCallbacks() {
     return ['liveFeedsLimit'];
   }

--- a/src/Plugin/Block/LiveFeedsNews.php
+++ b/src/Plugin/Block/LiveFeedsNews.php
@@ -37,10 +37,11 @@ class LiveFeedsNews extends BlockBase implements ContainerFactoryPluginInterface
   private ApStyleDateFormatter $apStyleDateFormatter;
 
   /**
+   * The Live Feeds Service.
+   *
    * @var \Drupal\live_feeds\GetFeed
    */
   private GetFeed $getFeed;
-
 
   /**
    * Construct.
@@ -56,6 +57,7 @@ class LiveFeedsNews extends BlockBase implements ContainerFactoryPluginInterface
    * @param \Drupal\live_feeds\GetFeed $getFeed
    *   Service to retrieve RSS feeds.
    * @param \Drupal\date_ap_style\ApStyleDateFormatter $apStyleDateFormatter
+   *   The Date AP Style Formatter.
    */
   public function __construct(
     array $configuration,
@@ -90,10 +92,10 @@ class LiveFeedsNews extends BlockBase implements ContainerFactoryPluginInterface
    */
   public function defaultConfiguration() {
     return [
-        'live_feeds_news_link' => '',
-        'live_feeds_items_total' => $this->t('5'),
-        'live_feeds_news_word_limit' => $this->t('30'),
-      ] + parent::defaultConfiguration();
+      'live_feeds_news_link' => '',
+      'live_feeds_items_total' => $this->t('5'),
+      'live_feeds_news_word_limit' => $this->t('30'),
+    ] + parent::defaultConfiguration();
 
   }
 
@@ -156,6 +158,7 @@ class LiveFeedsNews extends BlockBase implements ContainerFactoryPluginInterface
     if ($xml !== FALSE) {
       // Need this to parse the description.
       $html = new \DOMDocument('1.0', 'UTF-8');
+      $teaser = '';
       libxml_use_internal_errors(TRUE);
       foreach ($xml->channel->item as $story) {
         if (++$items > (int) $this->configuration['live_feeds_items_total']) {


### PR DESCRIPTION
This commit makes several changes to prepare the Live Feeds module for a new release. It expands the supported versions of the drupal/date_ap_style dependency to include the 2.0 release. It also enhances the GetFeed service to use a logger service, so any failed requests to retrieve feeds can be more effectively logged. Other code readability and organization improvements included as well.